### PR TITLE
Moving to FontAwesome Pro, Cleaning up the button card image component

### DIFF
--- a/docsite/src/components/components/ButtonCardDarkPreview.astro
+++ b/docsite/src/components/components/ButtonCardDarkPreview.astro
@@ -2,7 +2,7 @@
 import BrowserPreview from "../preview/BrowserPreview";
 const template = `<div class="card card__button card__button--dark">
   <div class="card__button__content">
-    <span class="icon fa fa-fw fa-3x fa-solid fa-user-gear"></span>
+    <span class="icon fa fa-fw fa-3x fa-duotone fa-user-gear"></span>
     <p>
       You can also put <strong>Text Content</strong> into these button cards. This
       is useful for when you want to have more of a conversational tone or written
@@ -21,7 +21,7 @@ const template = `<div class="card card__button card__button--dark">
 <BrowserPreview title="Button Card: Dark" code={template} client:idle>
   <div class="card card__button card__button--dark">
     <div class="card__button__content">
-      <span class="icon fa fa-fw fa-3x fa-solid fa-user-gear"></span>
+      <span class="icon fa fa-fw fa-3x fa-duotone fa-user-gear"></span>
       <p>
         You can also put <strong>Text Content</strong> into these button cards. This
         is useful for when you want to have more of a conversational tone or written

--- a/docsite/src/components/components/ButtonCardImagePreview.astro
+++ b/docsite/src/components/components/ButtonCardImagePreview.astro
@@ -5,7 +5,7 @@ const template = `<div
   style="--bg-image: url(https://live.staticflickr.com/65535/52862915746_b0210a9e6a_h.jpg)"
 >
   <div class="card__button__content">
-    <h3>This is a Button Card Hero</h3>
+    <span class="icon fa fa-fw fa-3x fa-duotone fa-megaphone"></span>
     <p>
       It has a heading, and text content within. It also has a photo background.
     </p>
@@ -25,11 +25,15 @@ const template = `<div
     style="--bg-image: url(https://live.staticflickr.com/65535/52862915746_b0210a9e6a_h.jpg)"
   >
     <div class="card__button__content">
-      <h3>This is a Button Card Hero</h3>
+      <span class="icon fa fa-fw fa-3x fa-briefcase"></span>
       <p>
         It has a heading, and text content within. It also has a photo
         background.
       </p>
+      <ul>
+        <li>you can also do lists on these cards</li>
+        <li>Just like this list here</li>
+      </ul>
     </div>
     <div class="card__button__button">
       <a href="#" class="" target="_blank" title="do something here"

--- a/docsite/src/components/components/ButtonCardLightPreview.astro
+++ b/docsite/src/components/components/ButtonCardLightPreview.astro
@@ -2,7 +2,7 @@
 import BrowserPreview from "../preview/BrowserPreview";
 const template = `<div class="card card__button card__button--light">
   <div class="card__button__content">
-    <span class="icon fa fa-fw fa-3x fa-solid fa-circle-check"></span>
+    <span class="icon fa fa-fw fa-3x fa-duotone fa-megaphone"></span>
     <ul>
       <li>This is a "button card"</li>
       <li>It is used to link to a secondary site / location</li>
@@ -21,7 +21,7 @@ const template = `<div class="card card__button card__button--light">
 <BrowserPreview title="Button Card: Light" code={template} client:idle>
   <div class="card card__button card__button--light">
     <div class="card__button__content">
-      <span class="icon fa fa-fw fa-3x fa-solid fa-circle-check"></span>
+      <span class="icon fa fa-fw fa-3x fa-duotone fa-megaphone"></span>
       <ul>
         <li>This is a "button card"</li>
         <li>It is used to link to a secondary site / location</li>

--- a/docsite/src/components/components/ButtonCardWhitePreview.astro
+++ b/docsite/src/components/components/ButtonCardWhitePreview.astro
@@ -2,7 +2,7 @@
 import BrowserPreview from "../preview/BrowserPreview";
 const template = `<div class="card card__button card__button--white">
   <div class="card__button__content">
-    <span class="icon fa fa-fw fa-3x fa-solid fa-user-gear"></span>
+    <span class="icon fa fa-fw fa-3x fa-duotone fa-user-gear"></span>
     <p>
       You can also put <strong>Text Content</strong> into these button cards. This
       is useful for when you want to have more of a conversational tone or written
@@ -21,7 +21,7 @@ const template = `<div class="card card__button card__button--white">
 <BrowserPreview title="Button Card: White" code={template} client:idle>
   <div class="card card__button card__button--white">
     <div class="card__button__content">
-      <span class="icon fa fa-fw fa-3x fa-solid fa-user-gear"></span>
+      <span class="icon fa fa-fw fa-3x fa-duotone fa-user-gear"></span>
       <p>
         You can also put <strong>Text Content</strong> into these button cards. This
         is useful for when you want to have more of a conversational tone or written

--- a/docsite/src/components/preview/BrowserPreview.css
+++ b/docsite/src/components/preview/BrowserPreview.css
@@ -54,14 +54,29 @@
     background: var(--gray-50);
     padding: var(--size-1) var(--size-3);
     color: var(--gray-700);
+    font-size: var(--font-size-1);
+    font-family: var(--font-family-body);
     text-transform: uppercase;
-    letter-spacing: 0.1em;
-    font-size: small;
+    display: flex;
+    flex-direction: row;
+    gap: var(--size-2);
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+}
+
+.browser-preview__buttons button i {
+    color: var(--gray-700);
 }
 
 .browser-preview__buttons button:hover {
     background: var(--mint-50);
     border-color: var(--mint-300);
+    color: var(--mint-900);
+    cursor: pointer;
+}
+
+.browser-preview__buttons button:hover i {
     color: var(--mint-900);
 }
 

--- a/docsite/src/components/preview/BrowserPreview.tsx
+++ b/docsite/src/components/preview/BrowserPreview.tsx
@@ -97,10 +97,12 @@ const BrowserPreview: FunctionComponent<BrowserPreviewProps> = ({
       ) : null}
       <div className="browser-preview__buttons">
         <button className="btn--primary" onClick={handleViewSource}>
-          {isCodeVisible ? "Hide" : "View"} Source
+          <span>{isCodeVisible ? "Hide" : "View"} Source</span>
+          <i className="fa-duotone fa-code fa-lg"></i>
         </button>
         <button className="btn--secondary" onClick={handleCodeCopy}>
-          Copy Code
+          <span>Copy Code</span>
+          <i className="fa-duotone fa-copy fa-lg"></i>
         </button>
       </div>
     </div>

--- a/styles/_variables.css
+++ b/styles/_variables.css
@@ -7,7 +7,8 @@ It can be used independently of the other files, but it is a dependency at the t
 
 /* importing fonts */
 @import url("https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700");
-@import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css");
+/* this will only work on UFV domains for Ellucian Experience / MyUFV */
+@import url("https://kit.fontawesome.com/e44b3e5453.css");
 
 /* basic CSS resets */
 * {

--- a/styles/components.css
+++ b/styles/components.css
@@ -77,6 +77,8 @@ and pages. it depends on _variables.css */
 .card__button ul {
     width: 100%;
     padding-inline-start: 25px;
+    margin-top: 0;
+    margin-bottom: 0;
 }
 
 .card__button ul li {
@@ -174,7 +176,6 @@ and pages. it depends on _variables.css */
     text-shadow: 1px 1px 2px #000000;
     display: grid;
     place-items: center;
-    text-align: center;
 }
 
 .card__button--hero>* {

--- a/styles/primitives.css
+++ b/styles/primitives.css
@@ -11,3 +11,7 @@ it depends on _variables.css
 There's nothing in here yet...
 This will be implemented at a later date. 
 */
+
+.center {
+    text-align: center;
+}


### PR DESCRIPTION
## Summary of changes
- moved to a FontAwesome pro license so that we can use all the premium icons and variants. `_variables.css` still loads the CSS file but the file will only load on ufv.ca, github, and ellucian experience websites now due to our licensing. 
- Cleaned up the card image component so that text is no longer centered by default on the card. 
- Centering text can now be achieved on an element by element level using the `.center` class located in `primitives.css` 