### PR TITLE
docs: adding archival warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 > [!WARNING]  
 > UFV-ITS is actively working on migrating from this HTML/CSS based approach to a set of custom Ellucian Extension Card Templates that MyUFV administrators will be able to fully control themselves from within Ellucian Experience.
 > 
-> This means that this repository will be archived soon™️and that administrators will be able to create all their content directly in Ellucian Experience. 
+> This means that this repository will be archived soon™️ and that administrators will be able to create all their content directly in Ellucian Experience. 
 
 A set of design tokens, CSS files, and guidelines for designing MyUFV cards and components

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # MyUFV Design System
+
+> [!WARNING]  
+> UFV-ITS is actively working on migrating from this HTML/CSS based approach to a set of custom Ellucian Extension Card Templates that MyUFV administrators will be able to fully control themselves from within Ellucian Experience.
+> 
+> This means that this repository will be archived soon™️and that administrators will be able to create all their content directly in Ellucian Experience. 
+
 A set of design tokens, CSS files, and guidelines for designing MyUFV cards and components


### PR DESCRIPTION
This pull request adds a warning to the `README.md` file to inform users about the upcoming migration from the current HTML/CSS-based design system to Ellucian Extension Card Templates. It also notes that the repository will soon be archived as a result.

Documentation update:

* Added a prominent warning at the top of `README.md` to notify users about the migration to Ellucian Extension Card Templates and the planned archival of this repository.